### PR TITLE
Feature/server

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -5,7 +5,6 @@ name: Java CI with Maven
 
 on:
   push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ CLI application for signing PDF files.
 
 ## Features
 * Visible PDF signature in PDF (multi language support)
+* Invoke via CLI or via starting a server
 * Supported Signature type: PAdES
 * Supported Signature profiles: 
   * BASELINE-B
@@ -29,13 +30,17 @@ Usage:
       Default: false
     -c, --certificate
       certificate (chain) to be used
+    --config
+      use a configuration file
     --hint
       text to be displayed in signature field
+    --host
+      run as server with the given hostname
     --image
       Image to be placed in signature block
-  * -i, --input
+    -i, --input
       input pdf file
-  * -k, --key
+    -k, --key
       signature key file or keystore
     --left
       X coordinate of the signature block in cm
@@ -48,6 +53,9 @@ Usage:
       Page where the signature block should be placed. [-1] for last page
     -p, --passphrase
       passphrase for the signature key or keystore
+    --port
+      run as server with the given port
+      Default: 8090
     --timestamp
       include signed timestamp
       Default: false
@@ -60,9 +68,6 @@ Usage:
       use specific time stamping authority as source (if multiple given, will 
       be used in given order as fallback)
       Default: []
-    -v, --verbose
-      verbose output
-      Default: false
     --width
       width of the signature block in cm
       Default: 10.0
@@ -101,11 +106,20 @@ Then, PDFs can be signed via the [specified](src/main/resources/openapi.yml) `/p
 endpoint:
 
 ```bash
-curl --location --request POST 'http://localhost:8090/v1/sign' \
+curl --location --request POST 'http://localhost:8090/' \
 --header 'Content-Type: application/json' \
 --data-raw '{
   "input": "/path/to/pdf.pdf"
 }'
+```
+
+### Using a config file
+
+Instead of CLI parameters, you can also submit a configuration file with
+the same parameters and the possibility to lead multiple
+keys, as shown in [this example](src/test/resources/test-config.yml)
+
+java -jar open-pdf-sign.jar --config /path/to/config.yaml
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -83,6 +83,31 @@ java -jar open-pdf-sign.jar -i input.pdf -o output.pdf \
 If the `page` parameter is specified, a visible signature
 will be placed on the specified page.
 
+### Usage in server mode
+
+You can also run open-pdf-sign as a server application in order to
+only load certificates once and easily integrate it in applications where
+CLI invocations are not possible. Simply add the `--port` or `--hostname`
+parameters, e.g.
+
+```bash
+java -jar open-pdf-sign.jar -i input.pdf -o output.pdf \
+  -c /etc/letsencrypt/live/openpdfsign.org/fullchain.pem \
+  -k /etc/letsencrypt/live/openpdfsign.org/privkey.pem
+  --port 8090 --hostname 127.0.0.1
+```
+
+Then, PDFs can be signed via the [specified](src/main/resources/openapi.yml) `/pdf`
+endpoint:
+
+```bash
+curl --location --request POST 'http://localhost:8090/v1/sign' \
+--header 'Content-Type: application/json' \
+--data-raw '{
+  "input": "/path/to/pdf.pdf"
+}'
+```
+
 ## Development
 
 ### Requirements

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,8 @@
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
         <org.apache.pdfbox-version>2.0.26</org.apache.pdfbox-version>
+        <org.eclipse.jetty-version>9.4.49.v20220914</org.eclipse.jetty-version>
+        <jackson.version>2.13.2</jackson.version>
     </properties>
     <repositories>
         <repository>
@@ -122,6 +124,21 @@
             <artifactId>lombok</artifactId>
             <version>1.18.24</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+            <version>${org.eclipse.jetty-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-servlet</artifactId>
+            <version>${org.eclipse.jetty-version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
         </dependency>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,11 @@
             <artifactId>jackson-databind</artifactId>
             <version>${jackson.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
 
 
         <dependency>

--- a/src/main/java/org/openpdfsign/CLIApplication.java
+++ b/src/main/java/org/openpdfsign/CLIApplication.java
@@ -87,7 +87,7 @@ public class CLIApplication {
             ServerConnector connector = new ServerConnector(server);
             ServletHandler servletHandler = new ServletHandler();
             server.setHandler(servletHandler);
-            servletHandler.addServletWithMapping(SignerServlet.class,"/v1/sign");
+            servletHandler.addServletWithMapping(SignerServlet.class,"/*");
             connector.setPort(cla.getPort() > 0 ? cla.getPort() : 8090);
             connector.setHost(cla.getHostname() != null ? cla.getHostname() : "localhost");
             server.setConnectors(new Connector[] {connector});

--- a/src/main/java/org/openpdfsign/CommandLineArguments.java
+++ b/src/main/java/org/openpdfsign/CommandLineArguments.java
@@ -4,7 +4,10 @@ import com.beust.jcommander.Parameter;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.ToString;
+
+import java.util.ArrayList;
 
 @Getter
 @ToString
@@ -17,7 +20,7 @@ public class CommandLineArguments extends SignatureParameters {
     @Parameter(required = false, names = {"-o", "--output"}, description = "output pdf file")
     private String outputFile;
 
-    @Parameter(required = true, names = {"-k", "--key"}, description = "signature key file or keystore")
+    @Parameter(required = false, names = {"-k", "--key"}, description = "signature key file or keystore")
     @JsonProperty(value = "key", required = false)
     private String keyFile;
 
@@ -34,8 +37,27 @@ public class CommandLineArguments extends SignatureParameters {
     private boolean binaryOutput = false;
 
     @Parameter(required = false, names={"--port"}, description = "run as server with the given port")
+    @JsonProperty(value = "port")
     private int port;
 
     @Parameter(required = false, names={"--host"}, description = "run as server with the given hostname")
+    @JsonProperty(value = "hostname")
     private String hostname;
+
+    @Parameter(required = false, names={"--config"}, description = "use a configuration file")
+    private String configFile;
+
+    @JsonProperty("certificates")
+    private ArrayList<HostKeyCertificatePair> certificates;
+
+    @Getter
+    @Setter
+    public static class HostKeyCertificatePair {
+        @JsonProperty
+        private String host;
+        @JsonProperty("key")
+        private String keyFile;
+        @JsonProperty("certificate")
+        private String certificateFile;
+    }
 }

--- a/src/main/java/org/openpdfsign/CommandLineArguments.java
+++ b/src/main/java/org/openpdfsign/CommandLineArguments.java
@@ -41,7 +41,7 @@ public class CommandLineArguments extends SignatureParameters {
     private int port;
 
     @Parameter(required = false, names={"--host"}, description = "run as server with the given hostname")
-    @JsonProperty(value = "hostname")
+    @JsonProperty(value = "host")
     private String hostname;
 
     @Parameter(required = false, names={"--config"}, description = "use a configuration file")

--- a/src/main/java/org/openpdfsign/CommandLineArguments.java
+++ b/src/main/java/org/openpdfsign/CommandLineArguments.java
@@ -1,19 +1,24 @@
 package org.openpdfsign;
 
 import com.beust.jcommander.Parameter;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.ToString;
 
 @Getter
 @ToString
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class CommandLineArguments extends SignatureParameters {
-    @Parameter(required = true, names = {"-i", "--input"}, description = "input pdf file")
+    @Parameter(required = false, names = {"-i", "--input"}, description = "input pdf file")
+    @JsonProperty(value = "input", required = true)
     private String inputFile;
 
     @Parameter(required = false, names = {"-o", "--output"}, description = "output pdf file")
     private String outputFile;
 
     @Parameter(required = true, names = {"-k", "--key"}, description = "signature key file or keystore")
+    @JsonProperty(value = "key", required = false)
     private String keyFile;
 
     @Parameter(required = false, names={"-p","--passphrase"}, description = "passphrase for the signature key or keystore")
@@ -27,4 +32,10 @@ public class CommandLineArguments extends SignatureParameters {
 
     @Parameter(required = false, names={"-b", "--binary"}, description = "binary output of PDF")
     private boolean binaryOutput = false;
+
+    @Parameter(required = false, names={"--port"}, description = "run as server with the given port")
+    private int port;
+
+    @Parameter(required = false, names={"--host"}, description = "run as server with the given hostname")
+    private String hostname;
 }

--- a/src/main/java/org/openpdfsign/ServerConfigHolder.java
+++ b/src/main/java/org/openpdfsign/ServerConfigHolder.java
@@ -1,0 +1,23 @@
+package org.openpdfsign;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Getter
+@Setter
+public class ServerConfigHolder {
+    private static ServerConfigHolder INSTANCE = new ServerConfigHolder();
+
+    private CommandLineArguments params;
+    private Map<String, byte[]> keystores = new HashMap<>();
+    private char[] keystorePassphrase;
+
+    public static ServerConfigHolder getInstance() {
+        return INSTANCE;
+    }
+
+
+}

--- a/src/main/java/org/openpdfsign/SignatureParameters.java
+++ b/src/main/java/org/openpdfsign/SignatureParameters.java
@@ -1,6 +1,7 @@
 package org.openpdfsign;
 
 import com.beust.jcommander.Parameter;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -14,6 +15,7 @@ public class SignatureParameters {
     private String imageFile;
 
     @Parameter(required = false, names={"--page"}, description = "Page where the signature block should be placed. [-1] for last page")
+    @JsonProperty(value = "page")
     private Integer page;
 
     @Parameter(required = false, names={"--top"}, description = "Y coordinate of the signature block in cm")
@@ -29,6 +31,7 @@ public class SignatureParameters {
     private String hint;
 
     @Parameter(required = false, names={"--timestamp"}, description = "include signed timestamp")
+    @JsonProperty("timestamp")
     private Boolean useTimestamp = false;
 
     @Parameter(required = false, names={"--tsa"}, description = "use specific time stamping authority as source (if multiple given, will be used in given order as fallback)")

--- a/src/main/java/org/openpdfsign/Signer.java
+++ b/src/main/java/org/openpdfsign/Signer.java
@@ -21,6 +21,7 @@ import org.apache.pdfbox.pdmodel.PDDocument;
 import org.openpdfsign.dss.PdfBoxNativeTableObjectFactory;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -39,7 +40,7 @@ public class Signer {
     private static final float POINTS_PER_INCH = 72;
     private static final float POINTS_PER_MM = 1 / (10 * 2.54f) * POINTS_PER_INCH;
 
-    public void signPdf(Path pdfFile, Path outputFile, byte[] keyStore, char[] keyStorePassword, boolean binary, SignatureParameters params) throws IOException {
+    public void signPdf(Path pdfFile, Path outputFile, byte[] keyStore, char[] keyStorePassword, OutputStream binaryOutput, SignatureParameters params) throws IOException {
         boolean visibleSignature = params.getPage() != null;
         //https://github.com/apache/pdfbox/blob/trunk/examples/src/main/java/org/apache/pdfbox/examples/signature/CreateVisibleSignature2.java
         //https://ec.europa.eu/cefdigital/DSS/webapp-demo/doc/dss-documentation.html
@@ -161,8 +162,8 @@ public class Signer {
 
         DSSDocument signedDocument = service.signDocument(toSignDocument, signatureParameters, signatureValue);
         log.debug("Document signing complete");
-        if (binary) {
-            signedDocument.writeTo(System.out);
+        if (binaryOutput != null) {
+            signedDocument.writeTo(binaryOutput);
         } else {
             signedDocument.save(outputFile.toAbsolutePath().toString());
         }

--- a/src/main/java/org/openpdfsign/SignerServlet.java
+++ b/src/main/java/org/openpdfsign/SignerServlet.java
@@ -11,8 +11,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -20,9 +19,18 @@ public class SignerServlet extends HttpServlet {
     ObjectMapper mapper = new ObjectMapper();
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse res) throws ServletException, IOException {
-
-        Path path = Paths.get(req.getRequestURI());
         String keyPath = ServerConfigHolder.getInstance().getKeystores().keySet().stream().findFirst().get();
+
+        HashSet<String> headers = new HashSet<>(Collections.list(req.getHeaderNames()));
+        Path path;
+        if (headers.contains("X-Open-Pdf-Sign-File")) {
+            path = Paths.get(req.getHeader("X-Open-Pdf-Sign-File"));
+        }
+        else {
+            path = Paths.get(req.getRequestURI());
+        }
+
+
 
         Signer s = new Signer();
         res.setStatus(HttpServletResponse.SC_OK);

--- a/src/main/java/org/openpdfsign/SignerServlet.java
+++ b/src/main/java/org/openpdfsign/SignerServlet.java
@@ -1,0 +1,72 @@
+package org.openpdfsign;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.IOUtils;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+public class SignerServlet extends HttpServlet {
+    ObjectMapper mapper = new ObjectMapper();
+
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse res) throws ServletException, IOException {
+        //get path
+        Path path;
+        String keyPath;
+        Map<String, String> errorMap = new HashMap<>();
+        if (req.getContentType().equals("application/json")) {
+            String requestAsJson = req.getReader().lines().collect(Collectors.joining());
+            try {
+                CommandLineArguments args = mapper.reader().readValue(requestAsJson, CommandLineArguments.class);
+                path = Paths.get(args.getInputFile());
+                keyPath = args.getKeyFile();
+            }
+            catch(RuntimeException e) {
+                errorMap.put("error","invalid json arguments");
+                res.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+                res.getOutputStream().print(mapper.writeValueAsString(errorMap));
+                return;
+            }
+        } else {
+            errorMap.put("error","invalid json");
+            res.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            res.getOutputStream().print(mapper.writeValueAsString(errorMap));
+            return;
+        }
+
+        if (!path.toFile().exists()) {
+            res.setStatus(HttpServletResponse.SC_NOT_FOUND);
+            return;
+        }
+
+        //key needs to be loaded OR not given
+        if (keyPath == null) {
+            keyPath = ServerConfigHolder.getInstance().getKeystores().keySet().stream().findFirst().get();
+        } else if (!ServerConfigHolder.getInstance().getKeystores().containsKey(keyPath)) {
+            errorMap.put("error","keyfile not loaded on server startup");
+            res.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            res.getOutputStream().print(mapper.writeValueAsString(errorMap));
+            return;
+        }
+
+        //sign pdf
+        Signer s = new Signer();
+        res.setStatus(HttpServletResponse.SC_OK);
+        res.setHeader("Content-Disposition", "attachment; filename=\"" + path.getFileName().toString() + "\"");
+        s.signPdf(path, null, ServerConfigHolder.getInstance().getKeystores().get(keyPath), ServerConfigHolder.getInstance().getKeystorePassphrase(), res.getOutputStream(), ServerConfigHolder.getInstance().getParams());
+        log.debug("signed " + path + " with " + keyPath);
+        res.getOutputStream().flush();
+    }
+}

--- a/src/main/java/org/openpdfsign/SignerServlet.java
+++ b/src/main/java/org/openpdfsign/SignerServlet.java
@@ -64,6 +64,11 @@ public class SignerServlet extends HttpServlet {
             }
         }
 
+        if (!path.toFile().exists()) {
+            res.setStatus(HttpServletResponse.SC_NOT_FOUND);
+            res.getOutputStream().flush();
+            return;
+        }
 
         Signer s = new Signer();
         res.setStatus(HttpServletResponse.SC_OK);
@@ -97,6 +102,23 @@ public class SignerServlet extends HttpServlet {
             res.setStatus(HttpServletResponse.SC_BAD_REQUEST);
             res.getOutputStream().print(mapper.writeValueAsString(errorMap));
             return;
+        }
+
+        if (keyPath != null) {
+            if (ServerConfigHolder.getInstance().getKeystores().containsKey(keyPath)) {
+                //key matches
+            }
+            else if (ServerConfigHolder.getInstance().getKeystores().containsKey("_")) {
+                keyPath = "_";
+            }
+            else {
+                //key not found, exception
+                res.setStatus(400);
+                res.getOutputStream().println("no key loaded for host");
+                res.getOutputStream().flush();
+                log.debug("received request with invalid host header, no default key: ", keyPath);
+                return;
+            }
         }
 
         if (!path.toFile().exists()) {

--- a/src/main/java/org/openpdfsign/SignerServlet.java
+++ b/src/main/java/org/openpdfsign/SignerServlet.java
@@ -18,7 +18,19 @@ import java.util.stream.Collectors;
 @Slf4j
 public class SignerServlet extends HttpServlet {
     ObjectMapper mapper = new ObjectMapper();
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse res) throws ServletException, IOException {
 
+        Path path = Paths.get(req.getRequestURI());
+        String keyPath = ServerConfigHolder.getInstance().getKeystores().keySet().stream().findFirst().get();
+
+        Signer s = new Signer();
+        res.setStatus(HttpServletResponse.SC_OK);
+        res.setHeader("Content-Disposition", "attachment; filename=\"" + path.getFileName().toString() + "\"");
+        s.signPdf(path, null, ServerConfigHolder.getInstance().getKeystores().get(keyPath), ServerConfigHolder.getInstance().getKeystorePassphrase(), res.getOutputStream(), ServerConfigHolder.getInstance().getParams());
+        log.debug("signed " + path + " with " + keyPath);
+        res.getOutputStream().flush();
+    }
 
     @Override
     protected void doPost(HttpServletRequest req, HttpServletResponse res) throws ServletException, IOException {

--- a/src/main/resources/openapi.yml
+++ b/src/main/resources/openapi.yml
@@ -1,0 +1,33 @@
+openapi: '3.0.0'
+info:
+  version: '1.0.0'
+  title: 'open-pdf-sign'
+  description: Sign pdfs
+
+paths:
+  /sign:
+    post:
+      summary: Sign a PDF
+      requestBody:
+        description: Information about signature
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              properties:
+                input:
+                  type: string
+                  example: /tmp/pdf-to-sign.pdf
+                key:
+                  type: string
+                  example: /etc/letsencrypt/live/openpdfsign.org/privkey.pem
+                  description: Key to use for signature in case multiple loaded.
+                    Has to be loaded. If none  given, first loaded key will be used.
+      responses:
+        '200':
+          description: The signed PDF attached
+          content:
+            application/pdf:
+              schema:
+                type: string
+                format: binaryl

--- a/src/main/resources/openapi.yml
+++ b/src/main/resources/openapi.yml
@@ -1,11 +1,44 @@
 openapi: '3.0.0'
 info:
   version: '1.0.0'
-  title: 'open-pdf-sign'
-  description: Sign pdfs
-
+  title: 'open-pdf-sign server mode API'
+  description: Sign pdfs via server
+servers:
+  - url: http://localhost:8090
 paths:
-  /sign:
+  /:
+    get:
+      summary: Sign a PDF - endpoint for nginx
+      parameters:
+        - in: header
+          name: X-Open-Pdf-Sign-Nginx-Version
+          schema:
+            type: string
+          example: 1.0.0
+          description: Version of nginx open-pdf-sign helper
+        - in: header
+          name: X-Open-Pdf-Sign-File
+          schema:
+            type: string
+          example: /var/www/site/x.pdf
+          description: Path of PDF
+        - in: header
+          name: Host
+          schema:
+            type: string
+          example: example.com
+          description: Hostname to use, needs to have loaded certificate
+      responses:
+        '200':
+          description: The signed PDF attached
+          content:
+            applocation/pdf:
+              schema:
+                type: string
+                format: binary
+        '404':
+          description: No file of the given path, or no access rights
+
     post:
       summary: Sign a PDF
       requestBody:
@@ -20,7 +53,7 @@ paths:
                   example: /tmp/pdf-to-sign.pdf
                 key:
                   type: string
-                  example: /etc/letsencrypt/live/openpdfsign.org/privkey.pem
+                  example: example.com
                   description: Key to use for signature in case multiple loaded.
                     Has to be loaded. If none  given, first loaded key will be used.
       responses:
@@ -30,4 +63,6 @@ paths:
             application/pdf:
               schema:
                 type: string
-                format: binaryl
+                format: binary
+        '404':
+          description: No file of the given path, or no access rights

--- a/src/main/resources/simplelogger.properties
+++ b/src/main/resources/simplelogger.properties
@@ -2,3 +2,4 @@ org.slf4j.simpleLogger.defaultLogLevel=info
 org.slf4j.simpleLogger.log.eu.europa=error
 org.slf4j.simpleLogger.showDateTime=true
 org.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss.SSS
+org.slf4j.simpleLogger.log.org.eclipse.jetty=info

--- a/src/test/java/org/openpdfsign/CLIApplicationTest.java
+++ b/src/test/java/org/openpdfsign/CLIApplicationTest.java
@@ -1,0 +1,62 @@
+package org.openpdfsign;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.net.URISyntaxException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class CLIApplicationTest {
+
+    @Test
+    void testParseArguments() {
+        String[] args = new String[]{
+                "-k", getClass().getClassLoader().getResource("key.pem").toString(),
+                "-c", getClass().getClassLoader().getResource("cert.pem").toString(),
+                "-i", getClass().getClassLoader().getResource("demo.pdf").toString(),
+                "-o", "output.pdf"
+        };
+        CommandLineArguments cla = CLIApplication.parseArguments(args);
+        assertEquals("output.pdf", cla.getOutputFile());
+    }
+
+    @Test
+    void testParseArgumentsBinary() {
+        String[] args = new String[]{
+                "-k", getClass().getClassLoader().getResource("key.pem").toString(),
+                "-c", getClass().getClassLoader().getResource("cert.pem").toString(),
+                "-i", getClass().getClassLoader().getResource("demo.pdf").toString(),
+                "-b"
+        };
+        CommandLineArguments cla = CLIApplication.parseArguments(args);
+        assertEquals(true, cla.isBinaryOutput());
+    }
+
+    @Test
+    void testParseArgumentsOutputMissing() {
+        String[] args = new String[]{
+                "-k", getClass().getClassLoader().getResource("key.pem").toString(),
+                "-c", getClass().getClassLoader().getResource("cert.pem").toString(),
+                "-i", getClass().getClassLoader().getResource("demo.pdf").toString(),
+        };
+        CommandLineArguments cla = CLIApplication.parseArguments(args);
+        assertEquals(null, cla);
+    }
+
+    @Test
+    void testParseArgumentsFromYaml() throws URISyntaxException {
+        String[] args = new String[]{
+                "--config", (new File(getClass().getClassLoader().getResource("test-config.yml").toURI()).getAbsolutePath())
+        };
+        CommandLineArguments cla = CLIApplication.parseArguments(args);
+        assertEquals(5, cla.getCertificates().size());
+        assertEquals("_",cla.getCertificates().get(0));
+        assertEquals("exampleA.com",cla.getCertificates().get(0));
+        assertEquals("exampleB.com",cla.getCertificates().get(0));
+        assertEquals("exampleC.com",cla.getCertificates().get(0));
+        assertEquals("example.com",cla.getCertificates().get(0));
+
+    }
+
+}

--- a/src/test/java/org/openpdfsign/CLIApplicationTest.java
+++ b/src/test/java/org/openpdfsign/CLIApplicationTest.java
@@ -51,11 +51,11 @@ class CLIApplicationTest {
         };
         CommandLineArguments cla = CLIApplication.parseArguments(args);
         assertEquals(5, cla.getCertificates().size());
-        assertEquals("_",cla.getCertificates().get(0));
-        assertEquals("exampleA.com",cla.getCertificates().get(0));
-        assertEquals("exampleB.com",cla.getCertificates().get(0));
-        assertEquals("exampleC.com",cla.getCertificates().get(0));
-        assertEquals("example.com",cla.getCertificates().get(0));
+        assertEquals("_",cla.getCertificates().get(0).getHost());
+        assertEquals("exampleA.com",cla.getCertificates().get(1).getHost());
+        assertEquals("exampleB.com",cla.getCertificates().get(2).getHost());
+        assertEquals("exampleC.com",cla.getCertificates().get(3).getHost());
+        assertEquals("example.com",cla.getCertificates().get(4).getHost());
 
     }
 

--- a/src/test/java/org/openpdfsign/SignerTest.java
+++ b/src/test/java/org/openpdfsign/SignerTest.java
@@ -40,7 +40,7 @@ class SignerTest {
         params.setImageFile(image.toAbsolutePath().toString());
 
         Signer signer = new Signer();
-        signer.signPdf(Paths.get(demoPdf.toURI()), Paths.get("signed3.pdf"),keyStore,keyStorePassword, true, params);
+        signer.signPdf(Paths.get(demoPdf.toURI()), Paths.get("signed3.pdf"),keyStore,keyStorePassword, null, params);
         System.out.println(2 + demoPdf.toString());
     }
 }

--- a/src/test/resources/test-config.yml
+++ b/src/test/resources/test-config.yml
@@ -1,0 +1,17 @@
+# default location: /etc/openpdfsign/config.yml
+# CLI invoke like: java -jar open-pdf-sign.jar --config /etc/openpdfsign/config.yml
+
+port: 8081 # port where open-pdf-sign is listening
+host: 127.0.0.1 # host address where open-pdf-sign server is listening
+# page: -1 # if not set, no visible signature
+# timestamp: false
+certificates:
+  - host: _ # default case
+    key: /etc/letsencrypt/live/example.com/key.pem
+    certificate: /etc/letsencrypt/live/example.com/fullchaim.pem
+  - host: exampleA.com exampleB.com exampleC.com # space separated, as in nginx conf
+    key: /etc/letsencrypt/live/example.com/key.pem
+    certificate: /etc/letsencrypt/live/example.com/fullchaim.pem
+  - host: example.com
+    key: /etc/letsencrypt/live/example.com/key.pem
+    certificate: /etc/letsencrypt/live/example.com/fullchaim.pem


### PR DESCRIPTION
Add server mode with POST endpoint to sign PDFs

Merge already as it's blocking @superphil0 in [open-pdf-sign-configurator](https://github.com/open-pdf-sign/open-pdf-sign-configurator) and there needs to be a "main" release for his work, as a beta doesn't suffice. Not yet all tests done, but doc should somehow match the behaviour. Still need to implement some security checks for server mode, but this should not affect the already existing CLI usage.

So please treat the server mode API as unstable.

