### PR TITLE
improve README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,159 +1,158 @@
 # open-pdf-sign
 
-The `open-pdf-sign` CLI application allows to
-easily sign PDF files from the commandline. Signatures
-can be invisible or visible, and visible signatures can be 
-customized. 
+The `open-pdf-sign` CLI application allows to easily sign PDF files from the command line. 
+Signatures can be invisible (default) or visible (can be customized). 
 
 ## Features
+
 * Visible PDF signature in PDF (multi language support)
 * Invoke via CLI or via starting a server
-* Supported Signature type: PAdES
-* Supported Signature profiles: 
+* Supported signature type: PAdES
+* Supported signature profiles: 
   * BASELINE-B
   * BASELINE-T
   * To be evaluated: BASELINE-LT, BASELINE-LTA
 
 ## Get Started
 
-Download the latest jar archive from the [GitHub releases page](https://github.com/open-pdf-sign/open-pdf-sign/releases) or in your terminal:
+Download the latest JAR from the [GitHub releases page](https://github.com/open-pdf-sign/open-pdf-sign/releases) or in your terminal:
 
-```bash
-curl -L https://github.com/open-pdf-sign/open-pdf-sign/releases/latest/download/open-pdf-sign.jar -o open-pdf-sign.jar
+```shell
+curl --location --output open-pdf-sign.jar \
+  https://github.com/open-pdf-sign/open-pdf-sign/releases/latest/download/open-pdf-sign.jar
 ```
 
 Make sure that Java is installed in at least version 8.
 
 ### Run
-```
-java -jar open-pdf-sign.jar -i input.pdf -o output.pdf -c certificate.crt -k keyfile.pem -p key_passphrase --page -1 --locale de-AT
+
+```shell
+java -jar open-pdf-sign.jar \
+  --input input.pdf --output output.pdf \
+  --certificate certificate.crt --key keyfile.pem --passphrase key_passphrase \
+  --page -1 --locale de-AT
 ```
 
 Usage:
-```
-  Options:
-    -b, --binary
-      binary output of PDF
-      Default: false
-    -c, --certificate
-      certificate (chain) to be used
-    --config
-      use a configuration file
-    --hint
-      text to be displayed in signature field
-    --host
-      run as server with the given hostname
-    --image
-      Image to be placed in signature block
-    -i, --input
-      input pdf file
-    -k, --key
-      signature key file or keystore
-    --left
-      X coordinate of the signature block in cm
-      Default: 1.0
-    -l, --locale
-      Locale, e.g. de-AT
-    -o, --output
-      output pdf file
-    --page
-      Page where the signature block should be placed. [-1] for last page
-    -p, --passphrase
-      passphrase for the signature key or keystore
-    --port
-      run as server with the given port
-      Default: 8090
-    --timestamp
-      include signed timestamp
-      Default: false
-    --timezone
-      use specific timezone for time info, e.g. Europe/Vienna
-    --top
-      Y coordinate of the signature block in cm
-      Default: 1.0
-    --tsa
-      use specific time stamping authority as source (if multiple given, will 
-      be used in given order as fallback)
-      Default: []
-    --width
-      width of the signature block in cm
-      Default: 10.0
+
+```text
+Options:
+  -b, --binary
+    binary output of PDF
+    Default: false
+  -c, --certificate
+    certificate (chain) to be used
+  --config
+    use a configuration file
+  --hint
+    text to be displayed in signature field
+  --host
+    run as server with the given hostname
+  --image
+    Image to be placed in signature block
+  -i, --input
+    input pdf file
+  -k, --key
+    signature key file or keystore
+  --left
+    X coordinate of the signature block in cm
+    Default: 1.0
+  -l, --locale
+    Locale, e.g. de-AT
+  -o, --output
+    output pdf file
+  --page
+    Page where the signature block should be placed. [-1] for last page
+  -p, --passphrase
+    passphrase for the signature key or keystore
+  --port
+    run as server with the given port
+    Default: 8090
+  --timestamp
+    include signed timestamp
+    Default: false
+  --timezone
+    use specific timezone for time info, e.g. Europe/Vienna
+  --top
+    Y coordinate of the signature block in cm
+    Default: 1.0
+  --tsa
+    use specific time stamping authority as source (if multiple given, will 
+    be used in given order as fallback)
+    Default: []
+  --width
+    width of the signature block in cm
+    Default: 10.0
 ```
 
 ### Usage with Let's Encrypt certificates
 
 PDFs can also be signed using your existing Let's Encrypt certificate.
 
-```bash
-java -jar open-pdf-sign.jar -i input.pdf -o output.pdf \
-  -c /etc/letsencrypt/live/openpdfsign.org/fullchain.pem \
-  -k /etc/letsencrypt/live/openpdfsign.org/privkey.pem
+```shell
+java -jar open-pdf-sign.jar --input input.pdf --output output.pdf \
+  --certificate /etc/letsencrypt/live/openpdfsign.org/fullchain.pem \
+  --key /etc/letsencrypt/live/openpdfsign.org/privkey.pem
 ```
 
 ### Visible signatures
 
-If the `page` parameter is specified, a visible signature
-will be placed on the specified page. For example, running
+If the `page` parameter is specified, a visible signature will be placed on the specified page. 
+For example, running
 
-```bash
-java -jar open-pdf-sign.jar -i input.pdf -o output.pdf \
-     -c certificate.crt \
-     -k key.pem \
+```shell
+java -jar open-pdf-sign.jar --input input.pdf --output output.pdf \
+     --certificate certificate.crt \
+     --key key.pem \
      --page -1 --image mylogo.png \
-     --hint "You can check the validity at signaturpruefung.gv.at"
+     --hint "You can check the validity at https://www.signaturpruefung.gv.at"
 ```
 
-will place a visible signature looking similar to the image below
-on the last page (`-1`) of the PDF document.
+will place a visible signature looking similar to the image below on the last page (`-1`) of the PDF document.
 
 ![signature image](https://www.openpdfsign.org/images/signature.png)
 
 
 ### Usage in server mode
 
-You can also run open-pdf-sign as a server application in order to
-only load certificates once and easily integrate it in applications where
-CLI invocations are not possible. Simply add the `--port` or `--hostname`
-parameters, e.g.
+You can also run open-pdf-sign as a server application in order to only load certificates once and easily integrate it in applications where CLI invocations are not possible. 
+Simply add the `port` or `hostname` parameters, e.g.
 
-```bash
-java -jar open-pdf-sign.jar -i input.pdf -o output.pdf \
-  -c /etc/letsencrypt/live/openpdfsign.org/fullchain.pem \
-  -k /etc/letsencrypt/live/openpdfsign.org/privkey.pem
+```shell
+java -jar open-pdf-sign.jar --input input.pdf --output output.pdf \
+  --certificate /etc/letsencrypt/live/openpdfsign.org/fullchain.pem \
+  --key /etc/letsencrypt/live/openpdfsign.org/privkey.pem
   --port 8090 --hostname 127.0.0.1
 ```
 
-Then, PDFs can be signed via the [specified](src/main/resources/openapi.yml) `/pdf`
-endpoint:
+Then, PDFs can be signed via the [specified](src/main/resources/openapi.yml) POST request:
 
-```bash
-curl --location --request POST 'http://localhost:8090/' \
---header 'Content-Type: application/json' \
---data-raw '{
-  "input": "/path/to/pdf.pdf"
-}'
+```shell
+curl --location 'http://localhost:8090/' \
+  --header 'Content-Type: application/json' \
+  --data-raw '{"input":"/path/to/pdf.pdf"}'
 ```
 
 ### Using a config file
 
-Instead of CLI parameters, you can also submit a configuration file with
-the same parameters and the possibility to lead multiple
-keys, as shown in [this example](src/test/resources/test-config.yml)
+Instead of specifying everything via CLI parameters, you can also use a configuration file (e.g. [this one](src/test/resources/test-config.yml)):
 
-```bash
+```shell
 java -jar open-pdf-sign.jar --config /path/to/config.yaml
 ```
+
+This way, you could also configure multiple (virtual) hosts.
 
 ## Development
 
 ### Requirements
-* Maven (https://maven.apache.org/)
-* JDK 8
 
+* [Maven](https://maven.apache.org/)
+* JDK 8
 
 ### Build
 
-```bash
+```shell
 mvn package
 ```
 


### PR DESCRIPTION
* put each sentence on a single line; separate sentences with a single newline
* add empty lines between heading and content; text and code block
* consistently use long CLI parameters
* consistently refer to CLI parameters without `--`
* use `shell` (instead of `bash`) as the syntax indication for code blocks holding CLI instructions
* update `--hint` to match the example image
* "specified `/pdf` endpoint" is misleading (there is no `/pdf` HTTP resource defined in the config file); replace with "specified POST request"
   * `-X POST` is not necessary when using [`-d` (or any of its sister parameters)](https://curl.se/docs/manpage.html#-d)
* improve description (and explain the advantages) of using a config file