### PR TITLE
Merge dev: Config file handling, stdin passphrase, README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ curl --location --output open-pdf-sign.jar \
   https://github.com/open-pdf-sign/open-pdf-sign/releases/latest/download/open-pdf-sign.jar
 ```
 
+Alternatively, open-pdf-sign is also available on [nix](https://github.com/NixOS/nixpkgs/tree/master/pkgs/tools/misc/open-pdf-sign),
+a wrapper is available on [npm](https://www.npmjs.com/package/open-pdf-sign), and alongside a installer for [nginx](https://github.com/open-pdf-sign/open-pdf-sign-configurator).
+
 Make sure that Java is installed in at least version 8.
 
 ### Run
@@ -160,4 +163,6 @@ mvn package
 
 This project is licensed under the [Apache 2.0-License](LICENSE).  
 The code contained in the [org/openpdfsign/dss subfolder](https://github.com/open-pdf-sign/open-pdf-sign/tree/master/src/main/java/org/openpdfsign/dss)
-extends and modifies code from the [dss project](https://github.com/esig/dss/) which is licensed under the [LGPL-2.1 license](https://github.com/esig/dss/blob/master/LICENSE).
+extends and modifies code from the [dss project](https://github.com/esig/dss/) which is licensed under the [LGPL-2.1 license](https://github.com/esig/dss/blob/master/LICENSE).  
+
+This project received financial support from [netidee](https://www.netidee.at/open-pdf-sign).

--- a/src/main/java/org/openpdfsign/CLIApplication.java
+++ b/src/main/java/org/openpdfsign/CLIApplication.java
@@ -21,6 +21,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ListIterator;
 import java.util.Locale;
+import java.util.Scanner;
 
 @Slf4j
 public class CLIApplication {
@@ -51,13 +52,26 @@ public class CLIApplication {
             keystorePassphrase = "123456789".toCharArray();
         }
         if (!Strings.isStringEmpty(cla.getCertificateFile()) &&
-            !Strings.isStringEmpty(cla.getKeyFile())) {
-            keystore = KeyStoreLoader.loadKeyStoreFromKeys(
-                    Paths.get(cla.getCertificateFile()),
-                    Paths.get(cla.getKeyFile()),
-                    (cla.getKeyPassphrase() == null) ? null : cla.getKeyPassphrase().toCharArray(),
-                    keystorePassphrase
-            );
+                !Strings.isStringEmpty(cla.getKeyFile())) {
+            try {
+                keystore = KeyStoreLoader.loadKeyStoreFromKeys(
+                        Paths.get(cla.getCertificateFile()),
+                        Paths.get(cla.getKeyFile()),
+                        (cla.getKeyPassphrase() == null) ? null : cla.getKeyPassphrase().toCharArray(),
+                        keystorePassphrase
+                );
+            } catch (KeyStoreLoader.KeyIsNeededException e) {
+                //load key from stdin if not provided
+                System.out.print("Please provide passphrase for private key file> ");
+                Scanner in = new Scanner(System.in);
+                String userPassphrase = in.nextLine();
+                keystore = KeyStoreLoader.loadKeyStoreFromKeys(
+                        Paths.get(cla.getCertificateFile()),
+                        Paths.get(cla.getKeyFile()),
+                        userPassphrase.toCharArray(),
+                        keystorePassphrase
+                );
+            }
             log.debug("Key and Certificate loaded");
 
         }

--- a/src/main/java/org/openpdfsign/CommandLineArguments.java
+++ b/src/main/java/org/openpdfsign/CommandLineArguments.java
@@ -10,6 +10,7 @@ import lombok.ToString;
 import java.util.ArrayList;
 
 @Getter
+@Setter
 @ToString
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CommandLineArguments extends SignatureParameters {
@@ -22,6 +23,7 @@ public class CommandLineArguments extends SignatureParameters {
     private String inputFile;
 
     @Parameter(required = false, names = {"-o", "--output"}, description = "output pdf file")
+    @JsonProperty("output")
     private String outputFile;
 
     @Parameter(required = false, names = {"-k", "--key"}, description = "signature key file or keystore")
@@ -29,15 +31,19 @@ public class CommandLineArguments extends SignatureParameters {
     private String keyFile;
 
     @Parameter(required = false, names={"-p","--passphrase"}, description = "passphrase for the signature key or keystore")
+    @JsonProperty("passphrase")
     private String keyPassphrase;
 
     @Parameter(required = false, names={"-c", "--certificate"}, description = "certificate (chain) to be used")
+    @JsonProperty("certificate")
     private String certificateFile;
 
     @Parameter(required = false, names={"-l", "--locale"}, description = "Locale, e.g. de-AT")
+    @JsonProperty("locale")
     private String locale;
 
     @Parameter(required = false, names={"-b", "--binary"}, description = "binary output of PDF")
+    @JsonProperty("binary")
     private boolean binaryOutput = false;
 
     @Parameter(required = false, names={"--port"}, description = "run as server with the given port")

--- a/src/main/java/org/openpdfsign/CommandLineArguments.java
+++ b/src/main/java/org/openpdfsign/CommandLineArguments.java
@@ -14,7 +14,7 @@ import java.util.ArrayList;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CommandLineArguments extends SignatureParameters {
 
-    @Parameter(required = false, names = { "--help", "-h" }, description = "prints this page")
+    @Parameter(required = false, names = { "-h", "--help" }, description = "prints this page", help = true)
     private boolean help = false;
 
     @Parameter(required = false, names = { "-i", "--input" }, description = "input pdf file")

--- a/src/main/java/org/openpdfsign/KeyStoreLoader.java
+++ b/src/main/java/org/openpdfsign/KeyStoreLoader.java
@@ -37,7 +37,7 @@ public class KeyStoreLoader {
      * @throws KeyStoreException
      * @throws NoSuchAlgorithmException
      */
-    public static byte[] loadKeyStoreFromKeys(Path certificatePath, Path privateKeyPath, char[] privateKeyPassword, char[] keyStorePassword) throws IOException, CertificateException, OperatorCreationException, PKCSException, KeyStoreException, NoSuchAlgorithmException {
+    public static byte[] loadKeyStoreFromKeys(Path certificatePath, Path privateKeyPath, char[] privateKeyPassword, char[] keyStorePassword) throws IOException, CertificateException, OperatorCreationException, PKCSException, KeyStoreException, NoSuchAlgorithmException, KeyIsNeededException {
         //load key
         Security.addProvider(new BouncyCastleProvider());
 
@@ -68,6 +68,10 @@ public class KeyStoreLoader {
         Object readObject = privPemParser.readObject();
         PrivateKeyInfo privateKeyInfo = null;
         if (readObject instanceof PKCS8EncryptedPrivateKeyInfo) {
+            //throw exception if key is needed but no passphrase provided
+            if (privateKeyPassword == null) {
+                throw new KeyIsNeededException();
+            }
             PKCS8EncryptedPrivateKeyInfo o = (PKCS8EncryptedPrivateKeyInfo) readObject;
             JceOpenSSLPKCS8DecryptorProviderBuilder builder = new JceOpenSSLPKCS8DecryptorProviderBuilder();
             privateKeyInfo = o.decryptPrivateKeyInfo(builder.build(privateKeyPassword));
@@ -94,5 +98,9 @@ public class KeyStoreLoader {
         bos.close();
         byte[] bytes = bos.toByteArray();
         return bytes;
+    }
+
+    public static class KeyIsNeededException extends Exception {
+
     }
 }

--- a/src/main/java/org/openpdfsign/SignatureParameters.java
+++ b/src/main/java/org/openpdfsign/SignatureParameters.java
@@ -12,6 +12,7 @@ import java.util.List;
 @Setter
 public class SignatureParameters {
     @Parameter(required = false, names={"--image"}, description = "Image to be placed in signature block")
+    @JsonProperty("image")
     private String imageFile;
 
     @Parameter(required = false, names={"--page"}, description = "Page where the signature block should be placed. [-1] for last page")
@@ -19,15 +20,19 @@ public class SignatureParameters {
     private Integer page;
 
     @Parameter(required = false, names={"--top"}, description = "Y coordinate of the signature block in cm")
+    @JsonProperty("top")
     private float top = 1;
 
     @Parameter(required = false, names={"--left"}, description = "X coordinate of the signature block in cm")
+    @JsonProperty("left")
     private float left = 1;
 
     @Parameter(required = false, names={"--width"}, description = "width of the signature block in cm")
+    @JsonProperty("width")
     private float width = 10;
 
     @Parameter(required = false, names={"--hint"}, description = "text to be displayed in signature field")
+    @JsonProperty("hint")
     private String hint;
 
     @Parameter(required = false, names={"--timestamp"}, description = "include signed timestamp")
@@ -35,8 +40,10 @@ public class SignatureParameters {
     private Boolean useTimestamp = false;
 
     @Parameter(required = false, names={"--tsa"}, description = "use specific time stamping authority as source (if multiple given, will be used in given order as fallback)")
+    @JsonProperty("tsa")
     private List<String> TSA = new LinkedList<>();
 
     @Parameter(required = false, names = {"--timezone"}, description = "use specific timezone for time info, e.g. Europe/Vienna")
+    @JsonProperty("timezone")
     private String timezone;
 }

--- a/src/test/java/org/openpdfsign/CLIApplicationTest.java
+++ b/src/test/java/org/openpdfsign/CLIApplicationTest.java
@@ -59,4 +59,23 @@ class CLIApplicationTest {
 
     }
 
+    @Test
+    void testParseArgumentsFromYamlAndCLI() throws URISyntaxException {
+        String[] args = new String[]{
+                "--config",
+                (new File(getClass().getClassLoader().getResource("test-config-passphrase.yml").toURI()).getAbsolutePath()),
+                "--input", "demo.pdf",
+                "--output", "out.pdf",
+                "--width","15"
+        };
+        CommandLineArguments cla = CLIApplication.parseArguments(args);
+        assertEquals("KEY_PASSPHRASE", cla.getKeyPassphrase());
+        assertEquals("cert.crt", cla.getCertificateFile());
+        assertEquals("key.pem", cla.getKeyFile());
+        assertEquals("demo.pdf", cla.getInputFile());
+        assertEquals("out.pdf", cla.getOutputFile());
+        assertEquals(11,cla.getLeft());
+        assertEquals(15, cla.getWidth());
+    }
+
 }

--- a/src/test/java/org/openpdfsign/KeyStoreLoaderTest.java
+++ b/src/test/java/org/openpdfsign/KeyStoreLoaderTest.java
@@ -22,7 +22,7 @@ class KeyStoreLoaderTest {
     private final char[] keyStorePassword = "987654321".toCharArray();
 
     @Test
-    void testLoadKeyStoreFromPemKeys() throws URISyntaxException, CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException, OperatorCreationException, PKCSException, UnrecoverableKeyException {
+    void testLoadKeyStoreFromPemKeys() throws URISyntaxException, CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException, OperatorCreationException, PKCSException, UnrecoverableKeyException, KeyStoreLoader.KeyIsNeededException {
         URL pubKey = getClass().getClassLoader().getResource("cert.pem");
         URL privKey = getClass().getClassLoader().getResource("key.pem");
 
@@ -36,7 +36,17 @@ class KeyStoreLoaderTest {
     }
 
     @Test
-    void testLoadKeyStoreFromCrtKeys() throws URISyntaxException, CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException, OperatorCreationException, PKCSException, UnrecoverableKeyException {
+    void testLoadKeyWithMissingPassword() {
+        URL pubKey = getClass().getClassLoader().getResource("cert.pem");
+        URL privKey = getClass().getClassLoader().getResource("key.pem");
+
+        assertThrows(KeyStoreLoader.KeyIsNeededException.class,  () -> {
+            KeyStoreLoader.loadKeyStoreFromKeys(Paths.get(pubKey.toURI()), Paths.get(privKey.toURI()), null, keyStorePassword);
+        });
+    }
+
+    @Test
+    void testLoadKeyStoreFromCrtKeys() throws URISyntaxException, CertificateException, IOException, KeyStoreException, NoSuchAlgorithmException, OperatorCreationException, PKCSException, UnrecoverableKeyException, KeyStoreLoader.KeyIsNeededException {
         URL pubKey = getClass().getClassLoader().getResource("cert.crt");
         URL privKey = getClass().getClassLoader().getResource("key_nopass.pem");
 

--- a/src/test/java/org/openpdfsign/SignerTest.java
+++ b/src/test/java/org/openpdfsign/SignerTest.java
@@ -21,7 +21,7 @@ import java.util.Locale;
 class SignerTest {
 
     @Test
-    void testSignPdf() throws URISyntaxException, IOException, NoSuchAlgorithmException, CertificateException, OperatorCreationException, PKCSException, KeyStoreException {
+    void testSignPdf() throws URISyntaxException, IOException, NoSuchAlgorithmException, CertificateException, OperatorCreationException, PKCSException, KeyStoreException, KeyStoreLoader.KeyIsNeededException {
         URL pubKey = getClass().getClassLoader().getResource("cert.pem");
         URL privKey = getClass().getClassLoader().getResource("key.pem");
         Configuration.getInstance(new Locale("en","AT"));

--- a/src/test/resources/test-config-passphrase.yml
+++ b/src/test/resources/test-config-passphrase.yml
@@ -1,0 +1,4 @@
+certificate: cert.crt
+key: key.pem
+passphrase: KEY_PASSPHRASE
+left: 11


### PR DESCRIPTION
* Change `help` argument order (#20)
* Add reference to nix (#16) to README
* Allow supplying key passphrase by stdin input or by configuration file (#14)
* Fix unclear behaviour when both command line arguments as well as config file are supplied: In case of conflicting arguments, CLI arguments will override