### PR TITLE
Updated docs: added help option, fixed host option

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Options:
     certificate (chain) to be used
   --config
     use a configuration file
+  -h, --help
+    prints this page
   --hint
     text to be displayed in signature field
   --host
@@ -119,13 +121,13 @@ will place a visible signature looking similar to the image below on the last pa
 ### Usage in server mode
 
 You can also run open-pdf-sign as a server application in order to only load certificates once and easily integrate it in applications where CLI invocations are not possible. 
-Simply add the `port` or `hostname` parameters, e.g.
+Simply add the `port` or `host` parameters, e.g.
 
 ```shell
 java -jar open-pdf-sign.jar --input input.pdf --output output.pdf \
   --certificate /etc/letsencrypt/live/openpdfsign.org/fullchain.pem \
   --key /etc/letsencrypt/live/openpdfsign.org/privkey.pem
-  --port 8090 --hostname 127.0.0.1
+  --port 8090 --host 127.0.0.1
 ```
 
 Then, PDFs can be signed via the [specified](src/main/resources/openapi.yml) POST request:


### PR DESCRIPTION
The option with `--hostname` is not valid. Updated the docs to reflect the correct option which is `--host`

```
Error: Was passed main parameter '--hostname' but no main parameter was defined in your arg class
com.beust.jcommander.ParameterException: Was passed main parameter '--hostname' but no main parameter was defined in your arg class
        at com.beust.jcommander.JCommander.initMainParameterValue(JCommander.java:961)
        at com.beust.jcommander.JCommander.parseValues(JCommander.java:762)
        at com.beust.jcommander.JCommander.parse(JCommander.java:363)
        at com.beust.jcommander.JCommander.parse(JCommander.java:342)
        at org.openpdfsign.CLIApplication.parseArguments(CLIApplication.java:138)
        at org.openpdfsign.CLIApplication.main(CLIApplication.java:31)
```