### PR TITLE
Added feature to just insert a signature image to the PDF file without digitally signing it

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Options:
     run as server with the given hostname
   --image
     Image to be placed in signature block
+  --just-image
+	  Just insert the signature image to the PDF file (the PDF will not be digitally signed). Use --left, --top and --width to place the image.
   -i, --input
     input pdf file
   -k, --key

--- a/src/main/java/org/openpdfsign/SignatureParameters.java
+++ b/src/main/java/org/openpdfsign/SignatureParameters.java
@@ -14,6 +14,9 @@ public class SignatureParameters {
     @Parameter(required = false, names={"--image"}, description = "Image to be placed in signature block")
     @JsonProperty("image")
     private String imageFile;
+		
+		@Parameter(required = false, names={"--just-image"}, description = "Sign by only inserting the specified image")    
+    private Boolean justImage = false;
 
     @Parameter(required = false, names={"--page"}, description = "Page where the signature block should be placed. [-1] for last page")
     @JsonProperty(value = "page")

--- a/src/test/java/org/openpdfsign/SignerTest.java
+++ b/src/test/java/org/openpdfsign/SignerTest.java
@@ -49,4 +49,25 @@ class SignerTest {
         signer.signPdf(Paths.get(demoPdf.toURI()), Paths.get("signed3.pdf"),keyStore,keyStorePassword, null, params);
         System.out.println(2 + demoPdf.toString());
     }
+		
+		@Test
+    void testSignPdfJustImage() throws URISyntaxException, IOException, NoSuchAlgorithmException, CertificateException, OperatorCreationException, PKCSException, KeyStoreException, KeyStoreLoader.KeyIsNeededException {
+        Configuration.getInstance(new Locale("en","AT"));
+        
+        URL demoPdf = getClass().getClassLoader().getResource("demo.pdf");
+
+        SignatureParameters params = new SignatureParameters();
+        params.setPage(-1);
+        params.setLeft(3);
+        params.setTop(24);
+        params.setWidth(15);
+        params.setJustImage(true);
+        Path image = Paths.get(getClass().getClassLoader().getResource("signature.png").toURI());
+        params.setImageFile(image.toAbsolutePath().toString());
+
+
+        Signer signer = new Signer();
+        signer.signPdf(Paths.get(demoPdf.toURI()), Paths.get("signed4.pdf"), null, null, null, params);
+        System.out.println(2 + demoPdf.toString());
+    }
 }


### PR DESCRIPTION
Added a feature to just insert a signature image to the PDF file without digitally signing it. This is achieved by using the `--just-image` option from the command line (the `--image` option is mandatory). The already existing options `--left`, `--top` and `--width` can still be used to position and resize the image.

Sorry guys if I messed up with the tests. I'm not very familiar with Java and its ecosystem. They passed though.