### PR TITLE
Long-Term Validation support (PAdES-LT and PAdES-LTA)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ Signatures can be invisible (default) or visible (can be customized).
 * Supported signature profiles: 
   * BASELINE-B
   * BASELINE-T
-  * To be evaluated: BASELINE-LT, BASELINE-LTA
+  * BASELINE-LT
+  * BASELINE-LTA
 
 ## Get Started
 
@@ -40,6 +41,10 @@ Usage:
 
 ```text
 Options:
+  --baseline-lt
+    use PAdES profile with long-term validation material
+  --baseline-lta
+    use PAdES profile with long term availability and integrity of validation material
   -b, --binary
     binary output of PDF
     Default: false
@@ -108,6 +113,22 @@ java -jar open-pdf-sign.jar --input input.pdf --output output.pdf \
   --certificate /etc/letsencrypt/live/openpdfsign.org/fullchain.pem \
   --key /etc/letsencrypt/live/openpdfsign.org/privkey.pem
 ```
+
+### Signing documents with long-term validation info (PAdES-LT)
+
+Sign documents with signatures that provides the long-term availability 
+of the validation material by incorporating all the material 
+or references to material required for validating the signature.  
+For this, using a timestamp is needed.
+
+```shell
+java -jar open-pdf-sign.jar --input input.pdf --output output.pdf \
+  --certificate /etc/letsencrypt/live/openpdfsign.org/fullchain.pem \
+  --key /etc/letsencrypt/live/openpdfsign.org/privkey.pem \
+  --timestamp --tsa http://timestamp.digicert.com
+  --baseline-lt
+```
+
 
 ### Visible signatures
 

--- a/pom.xml
+++ b/pom.xml
@@ -188,5 +188,15 @@
             <artifactId>slf4j-simple</artifactId>
             <version>1.7.36</version>
         </dependency>
+        <dependency>
+            <groupId>eu.europa.ec.joinup.sd-dss</groupId>
+            <artifactId>dss-crl-parser-stream</artifactId>
+            <version>${dss.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>eu.europa.ec.joinup.sd-dss</groupId>
+            <artifactId>dss-tsl-validation</artifactId>
+            <version>${dss.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/org/openpdfsign/SignatureParameters.java
+++ b/src/main/java/org/openpdfsign/SignatureParameters.java
@@ -42,6 +42,12 @@ public class SignatureParameters {
     @JsonProperty("timestamp")
     private Boolean useTimestamp = false;
 
+    @Parameter(required = false, names={"--baseline-lt"}, description = "use PAdES profile with long-term validation material")
+    private Boolean useLT = false;
+
+    @Parameter(required = false, names={"--baseline-lta"}, description = "use PAdES profile with long term availability and integrity of validation material")
+    private Boolean useLTA = false;
+
     @Parameter(required = false, names={"--label-hint"}, description = "label for the 'hint' row")
     private String labelHint;
 

--- a/src/main/java/org/openpdfsign/SignatureVerifier.java
+++ b/src/main/java/org/openpdfsign/SignatureVerifier.java
@@ -1,0 +1,91 @@
+package org.openpdfsign;
+
+import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import eu.europa.esig.dss.detailedreport.DetailedReport;
+import eu.europa.esig.dss.diagnostic.DiagnosticData;
+import eu.europa.esig.dss.model.DSSDocument;
+import eu.europa.esig.dss.model.FileDocument;
+import eu.europa.esig.dss.pades.signature.PAdESService;
+import eu.europa.esig.dss.service.crl.OnlineCRLSource;
+import eu.europa.esig.dss.service.ocsp.OnlineOCSPSource;
+import eu.europa.esig.dss.simplereport.SimpleReport;
+import eu.europa.esig.dss.spi.x509.CommonTrustedCertificateSource;
+import eu.europa.esig.dss.spi.x509.aia.DefaultAIASource;
+import eu.europa.esig.dss.validation.CommonCertificateVerifier;
+import eu.europa.esig.dss.validation.SignedDocumentValidator;
+import eu.europa.esig.dss.validation.reports.Reports;
+import eu.europa.esig.validationreport.jaxb.ValidationReportType;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.security.cert.CertificateException;
+import java.util.List;
+
+@Slf4j
+public class SignatureVerifier {
+
+    public void verifyPdfSignature(Path pdfFile) throws IOException, CertificateException {
+        //https://ec.europa.eu/digital-building-blocks/DSS/webapp-demo/doc/dss-documentation.html#_validating_an_ades_signature
+
+        //load PDF file in DSSDocument format
+        DSSDocument toValidateDocument = new FileDocument(pdfFile.toFile());
+
+        // Create common certificate verifier
+        CommonCertificateVerifier commonCertificateVerifier = new CommonCertificateVerifier();
+        // Create PAdESService for signature
+        PAdESService service = new PAdESService(commonCertificateVerifier);
+
+        // Capability to download resources from AIA
+        commonCertificateVerifier.setAIASource(new DefaultAIASource());
+
+        // Capability to request OCSP Responders
+        commonCertificateVerifier.setOcspSource(new OnlineOCSPSource());
+
+        // Capability to download CRL
+        commonCertificateVerifier.setCrlSource(new OnlineCRLSource());
+
+        // Create an instance of a trusted certificate source
+        CommonTrustedCertificateSource trustedCertSource = new CommonTrustedCertificateSource();
+
+        // import the keystore as trusted
+        trustedCertSource.importAsTrusted(TrustedCertificatesLoader.getDefaults());
+
+        // Add trust anchors (trusted list, keystore,...) to a list of trusted certificate sources
+        // Hint : use method {@code CertificateVerifier.setTrustedCertSources(certSources)} in order to overwrite the existing list
+        commonCertificateVerifier.addTrustedCertSources(trustedCertSource);
+
+
+        // We create an instance of DocumentValidator
+        // It will automatically select the supported validator from the classpath
+        SignedDocumentValidator documentValidator = SignedDocumentValidator.fromDocument(toValidateDocument);
+
+        // We add the certificate verifier (which allows to verify and trust certificates)
+        documentValidator.setCertificateVerifier(commonCertificateVerifier);
+
+
+
+        // Here, everything is ready. We can execute the validation (for the example, we use the default and embedded
+        // validation policy)
+        Reports reports = documentValidator.validateDocument();
+
+        // We have 4 reports
+        // The diagnostic data which contains all used and static data
+        DiagnosticData diagnosticData = reports.getDiagnosticData();
+
+        // The detailed report which is the result of the process of the diagnostic data and the validation policy
+        DetailedReport detailedReport = reports.getDetailedReport();
+
+        // The simple report is a summary of the detailed report (more user-friendly)
+        SimpleReport simpleReport = reports.getSimpleReport();
+
+        // The JAXB representation of the ETSI Validation report (ETSI TS 119 102-2)
+        ValidationReportType estiValidationReport = reports.getEtsiValidationReportJaxb();
+
+        ObjectMapper om = new ObjectMapper();
+        String s = om.writer(new DefaultPrettyPrinter()).writeValueAsString(simpleReport);
+        System.out.println(s);
+
+    }
+}

--- a/src/main/java/org/openpdfsign/Signer.java
+++ b/src/main/java/org/openpdfsign/Signer.java
@@ -9,7 +9,12 @@ import eu.europa.esig.dss.pades.PAdESSignatureParameters;
 import eu.europa.esig.dss.pades.SignatureImageParameters;
 import eu.europa.esig.dss.pades.signature.PAdESService;
 import eu.europa.esig.dss.pdf.pdfbox.PdfBoxNativeObjectFactory;
+import eu.europa.esig.dss.service.crl.OnlineCRLSource;
+import eu.europa.esig.dss.service.ocsp.OnlineOCSPSource;
 import eu.europa.esig.dss.service.tsp.OnlineTSPSource;
+import eu.europa.esig.dss.spi.x509.CommonCertificateSource;
+import eu.europa.esig.dss.spi.x509.CommonTrustedCertificateSource;
+import eu.europa.esig.dss.spi.x509.aia.DefaultAIASource;
 import eu.europa.esig.dss.spi.x509.tsp.CompositeTSPSource;
 import eu.europa.esig.dss.spi.x509.tsp.TSPSource;
 import eu.europa.esig.dss.token.JKSSignatureToken;
@@ -33,7 +38,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.TimeZone;
 
 @Slf4j
 public class Signer {
@@ -66,9 +70,15 @@ public class Signer {
         ;
         signatureParameters.setSigningCertificate(signingToken.getKey(keyAlias).getCertificate());
         signatureParameters.setCertificateChain(signingToken.getKey(keyAlias).getCertificateChain());
-        if (params.getUseTimestamp() || !params.getTSA().isEmpty()) {
-            signatureParameters.setSignatureLevel(SignatureLevel.PAdES_BASELINE_T);
+        if (params.getUseLT()) {
             //extra signature space for the use of a timestamped signature
+            signatureParameters.setSignatureLevel(SignatureLevel.PAdES_BASELINE_LT);
+            signatureParameters.setContentSize((int) (SignatureOptions.DEFAULT_SIGNATURE_SIZE * 1.5));
+        } else if (params.getUseLTA()) {
+            signatureParameters.setSignatureLevel(SignatureLevel.PAdES_BASELINE_LTA);
+            signatureParameters.setContentSize((int) (SignatureOptions.DEFAULT_SIGNATURE_SIZE * 1.75));
+        } else if (params.getUseTimestamp() || !params.getTSA().isEmpty()) {
+            signatureParameters.setSignatureLevel(SignatureLevel.PAdES_BASELINE_T);
             signatureParameters.setContentSize((int) (SignatureOptions.DEFAULT_SIGNATURE_SIZE * 1.5));
         } else {
             signatureParameters.setSignatureLevel(SignatureLevel.PAdES_BASELINE_B);
@@ -77,6 +87,34 @@ public class Signer {
 
         // Create common certificate verifier
         CommonCertificateVerifier commonCertificateVerifier = new CommonCertificateVerifier();
+
+        if (signatureParameters.getSignatureLevel() == SignatureLevel.PAdES_BASELINE_LT ||
+        signatureParameters.getSignatureLevel() == SignatureLevel.PAdES_BASELINE_LTA) {
+            // Capability to download resources from AIA
+            commonCertificateVerifier.setAIASource(new DefaultAIASource());
+
+            // Capability to request OCSP Responders
+            commonCertificateVerifier.setOcspSource(new OnlineOCSPSource());
+
+            // Capability to download CRL
+            commonCertificateVerifier.setCrlSource(new OnlineCRLSource());
+
+            // Still fetch revocation data for signing, even if a certificate chain is not trusted
+            commonCertificateVerifier.setCheckRevocationForUntrustedChains(true);
+
+            // Create an instance of a trusted certificate source
+            CommonTrustedCertificateSource trustedCertSource = new CommonTrustedCertificateSource();
+
+            // Import defaults
+            //CommonCertificateSource commonCertificateSource = TrustedCertificatesLoader.getDefaults();
+            CommonCertificateSource commonCertificateSource = new CommonCertificateSource();
+
+            // import the keystore as trusted
+            trustedCertSource.importAsTrusted(commonCertificateSource);
+
+            commonCertificateVerifier.addTrustedCertSources(trustedCertSource);
+        }
+
         // Create PAdESService for signature
         PAdESService service = new PAdESService(commonCertificateVerifier);
 

--- a/src/main/java/org/openpdfsign/Signer.java
+++ b/src/main/java/org/openpdfsign/Signer.java
@@ -180,7 +180,7 @@ public class Signer {
         //only use TSP source, if parameter is set
         //if it is set to an url, us this
         //otherwise, default
-        if (params.getUseTimestamp() || params.getTSA() != null) {
+        if (params.getUseTimestamp() || params.getUseLT() || params.getUseLTA() || params.getTSA() != null) {
             CompositeTSPSource compositeTSPSource = new CompositeTSPSource();
             Map<String, TSPSource> tspSources = new HashMap<>();
             compositeTSPSource.setTspSources(tspSources);

--- a/src/main/java/org/openpdfsign/TrustedCertificatesLoader.java
+++ b/src/main/java/org/openpdfsign/TrustedCertificatesLoader.java
@@ -1,0 +1,111 @@
+package org.openpdfsign;
+
+import eu.europa.esig.dss.model.x509.CertificateToken;
+import eu.europa.esig.dss.service.http.commons.CommonsDataLoader;
+import eu.europa.esig.dss.service.http.commons.FileCacheDataLoader;
+import eu.europa.esig.dss.spi.tsl.TrustedListsCertificateSource;
+import eu.europa.esig.dss.spi.x509.CommonCertificateSource;
+import eu.europa.esig.dss.tsl.job.TLValidationJob;
+import eu.europa.esig.dss.tsl.source.LOTLSource;
+import eu.europa.esig.dss.tsl.source.TLSource;
+import eu.europa.esig.dss.tsl.sync.AcceptAllStrategy;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.openssl.PEMParser;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.util.Arrays;
+
+public class TrustedCertificatesLoader {
+    public static CommonCertificateSource getDefaults() {
+        //@TODO: load from file system, if possible
+        CommonCertificateSource commonCertificateSource = new CommonCertificateSource();
+
+        Arrays.stream(Configuration.getInstance().getProperties().getStringArray("trusted_certificates")).forEach(source -> {
+            try {
+                CommonCertificateSource certSource = loadFromSource(source);
+                certSource.getCertificates().stream().forEach(cert -> commonCertificateSource.addCertificate(cert));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            } catch (CertificateException e) {
+                throw new RuntimeException(e);
+            }
+        });
+
+        return commonCertificateSource;
+    }
+
+    public static CommonCertificateSource loadFromSource(String source) throws IOException, CertificateException {
+        CommonCertificateSource commonCertificateSource = new CommonCertificateSource();
+
+        FileCacheDataLoader onlineFileLoader = new FileCacheDataLoader();
+        onlineFileLoader.setCacheExpirationTime(7 * 24 * 60 * 60 * 1000);
+        onlineFileLoader.setDataLoader(new CommonsDataLoader()); // instance of DataLoader which can access to Internet (proxy,...)
+        onlineFileLoader.setFileCacheDirectory(new File(System.getProperty("java.io.tmpdir") + File.separator + "open-pdf-sign"));
+
+        //case: URI
+        if (source.contains("lotl.xml")) {
+            //case LOTL
+            //https://ec.europa.eu/tools/lotl/eu-lotl.xml
+            // -- parse trusted list
+            TLValidationJob validationJob = new TLValidationJob();
+
+            //LOTL
+            LOTLSource lotlSource = new LOTLSource();
+            lotlSource.setCertificateSource(new CommonCertificateSource());
+            lotlSource.setUrl(source);
+
+            validationJob.setOnlineDataLoader(onlineFileLoader);
+            validationJob.setSynchronizationStrategy(new AcceptAllStrategy());
+            TrustedListsCertificateSource trustedListsCertificateSource = new TrustedListsCertificateSource();
+            validationJob.setTrustedListCertificateSource(trustedListsCertificateSource);
+            validationJob.setListOfTrustedListSources(lotlSource);
+            validationJob.onlineRefresh();
+
+            trustedListsCertificateSource.getCertificates().stream().forEach((cert) -> {
+                commonCertificateSource.addCertificate(cert);
+            });
+
+        }
+        else if (source.endsWith(".xml")) {
+            //trusted list
+            // -- parse trusted list
+            TLValidationJob validationJob = new TLValidationJob();
+            validationJob.setOnlineDataLoader(onlineFileLoader);
+            validationJob.setSynchronizationStrategy(new AcceptAllStrategy());
+            TrustedListsCertificateSource trustedListsCertificateSource = new TrustedListsCertificateSource();
+            TLSource tlSource = new TLSource();
+            tlSource.setCertificateSource(new CommonCertificateSource());
+            validationJob.setTrustedListCertificateSource(trustedListsCertificateSource);
+            tlSource.setUrl(source);
+
+            validationJob.setTrustedListSources(tlSource);
+            validationJob.onlineRefresh();
+
+            trustedListsCertificateSource.getCertificates().stream().forEach((cert) -> {
+                commonCertificateSource.addCertificate(cert);
+            });
+        }
+        else if (source.startsWith("https://")) {
+            onlineFileLoader.get(source);
+
+            byte[] result = onlineFileLoader.get(source);
+            PEMParser pemParser = new PEMParser(new InputStreamReader(new ByteArrayInputStream(result)));
+            while (true) {
+                X509CertificateHolder certHolder = (X509CertificateHolder) pemParser.readObject();
+                if (certHolder == null) {
+                    break;
+                }
+                X509Certificate cert = new JcaX509CertificateConverter().getCertificate(certHolder);
+                commonCertificateSource.addCertificate(new CertificateToken(cert));
+            }
+        }
+
+        return commonCertificateSource;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,6 @@
 tsp_sources=http://tsa.izenpe.com
 tsp_sources=http://kstamp.keynectis.com/KSign/
 tsp_sources=http://tss.accv.es:8318/tsa
+trusted_certificates=/etc/ssl/certs/
+trusted_certificates=/usr/local/share/ca-certificates/
+trusted_certificates=https://curl.se/ca/cacert.pem

--- a/src/test/java/org/openpdfsign/SignatureVerifierTest.java
+++ b/src/test/java/org/openpdfsign/SignatureVerifierTest.java
@@ -1,0 +1,16 @@
+package org.openpdfsign;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.security.cert.CertificateException;
+
+class SignatureVerifierTest {
+    @Test
+    public void testVerifyValidSignature() throws IOException, CertificateException {
+        SignatureVerifier verifier = new SignatureVerifier();
+        //@TODO
+    }
+
+}


### PR DESCRIPTION
This PR adds support for PAdES-LT and PAdES-LTA profiles as specified in ETSI 102 778. In these profiles, recovation data and a full certificate chain is embedded into the signature, allowing for long-term validation.

In user-centric terms, this will lead to a "Signature is LTV enabled" in Adobe Reader.

Closes #30