### PR TITLE
Allow setting certification level

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ Options:
     Default: false
   -c, --certificate
     certificate (chain) to be used
+  --certification
+      Quality of signature certification (DocMDP) and allowed changes after
+      signing
+      Default: certified-minimal-changes-permitted
+      Possible Values: [not-certified, certified-no-change-permitted, certified-minimal-changes-permitted, certified-changes-permitted]
   --config
     use a configuration file
   -h, --help

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <properties>
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
-        <org.apache.pdfbox-version>2.0.28</org.apache.pdfbox-version>
+        <org.apache.pdfbox-version>2.0.29</org.apache.pdfbox-version>
         <org.eclipse.jetty-version>9.4.49.v20220914</org.eclipse.jetty-version>
         <jackson.version>2.15.2</jackson.version>
         <dss.version>5.12.1</dss.version>
@@ -39,6 +39,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.2</version>
             </plugin>
+
             <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
                 <version>3.6.0</version>
@@ -163,13 +164,14 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
+            <version>5.10.0</version>
             <scope>test</scope>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk15on -->
+        <!-- https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk18on -->
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk18on</artifactId>
-            <version>1.72</version>
+            <version>1.76</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-configuration2 -->
         <dependency>

--- a/src/main/java/org/openpdfsign/SignatureParameters.java
+++ b/src/main/java/org/openpdfsign/SignatureParameters.java
@@ -1,6 +1,8 @@
 package org.openpdfsign;
 
 import com.beust.jcommander.Parameter;
+import com.beust.jcommander.converters.EnumConverter;
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 import lombok.Setter;
@@ -64,4 +66,58 @@ public class SignatureParameters {
     @Parameter(required = false, names = {"--timezone"}, description = "use specific timezone for time info, e.g. Europe/Vienna")
     @JsonProperty("timezone")
     private String timezone;
+
+    @Parameter(required = false, names={"--certification"}, converter = CertificationModeConverter.class, description = "Quality of signature certification (DocMDP) and allowed changes after signing")
+    @JsonProperty("certification")
+    private CertificationMode certification = CertificationMode.CERTIFIED_MINIMAL_CHANGES_PERMITTED;
+
+    public static enum CertificationMode {
+        NOT_CERTIFIED("not-certified"),
+        CERTIFIED_NO_CHANGE_PERMITTED("certified-no-change-permitted"),
+        CERTIFIED_MINIMAL_CHANGES_PERMITTED("certified-minimal-changes-permitted"),
+        CERTIFIED_CHANGES_PERMITTED("certified-changes-permitted");
+
+        private String certification;
+
+        CertificationMode(String certification) {
+            this.certification = certification;
+        }
+
+        @JsonCreator
+        public static CertificationMode forValue(String value) {
+            for (CertificationMode mode : CertificationMode.values()) {
+                if (mode.toString().equals(value)) {
+                    return mode;
+                }
+            }
+            return null;
+        }
+
+        @Override
+        public String toString() {
+            return certification;
+        }
+    }
+
+
+    public static class CertificationModeConverter extends EnumConverter<CertificationMode> {
+
+        public CertificationModeConverter(String optionName) {
+            super(optionName, CertificationMode.class);
+        }
+
+        @Override
+        public CertificationMode convert(String value) {
+            //value needs to be enum
+            CertificationMode mode = CertificationMode.forValue(value);
+            if (mode != null) {
+                return mode;
+            }
+
+            //call super class converter in order to get error message
+            return super.convert(value);
+        }
+    }
+
+
 }

--- a/src/main/java/org/openpdfsign/Signer.java
+++ b/src/main/java/org/openpdfsign/Signer.java
@@ -83,7 +83,23 @@ public class Signer {
         } else {
             signatureParameters.setSignatureLevel(SignatureLevel.PAdES_BASELINE_B);
         }
-        signatureParameters.setPermission(CertificationPermission.MINIMAL_CHANGES_PERMITTED);
+
+        //set certification level
+        switch (params.getCertification()) {
+            case NOT_CERTIFIED:
+                //don't set anything
+                break;
+            case CERTIFIED_NO_CHANGE_PERMITTED:
+                signatureParameters.setPermission(CertificationPermission.NO_CHANGE_PERMITTED);
+                break;
+            case CERTIFIED_CHANGES_PERMITTED:
+                signatureParameters.setPermission(CertificationPermission.CHANGES_PERMITTED);
+                break;
+            case CERTIFIED_MINIMAL_CHANGES_PERMITTED:
+            default:
+                signatureParameters.setPermission(CertificationPermission.MINIMAL_CHANGES_PERMITTED);
+                break;
+        }
 
         // Create common certificate verifier
         CommonCertificateVerifier commonCertificateVerifier = new CommonCertificateVerifier();

--- a/src/test/java/org/openpdfsign/CLIApplicationTest.java
+++ b/src/test/java/org/openpdfsign/CLIApplicationTest.java
@@ -31,6 +31,7 @@ class CLIApplicationTest {
         };
         CommandLineArguments cla = CLIApplication.parseArguments(args);
         assertEquals(true, cla.isBinaryOutput());
+        assertEquals(SignatureParameters.CertificationMode.CERTIFIED_MINIMAL_CHANGES_PERMITTED, cla.getCertification());
     }
 
     @Test
@@ -45,6 +46,20 @@ class CLIApplicationTest {
     }
 
     @Test
+    void testParseEnum() {
+        String[] args = new String[]{
+                "-k", getClass().getClassLoader().getResource("key.pem").toString(),
+                "-c", getClass().getClassLoader().getResource("cert.pem").toString(),
+                "-i", getClass().getClassLoader().getResource("demo.pdf").toString(),
+                "-b",
+                "--certification","not-certified"
+        };
+        CommandLineArguments cla = CLIApplication.parseArguments(args);
+        assertEquals(true, cla.isBinaryOutput());
+        assertEquals(SignatureParameters.CertificationMode.NOT_CERTIFIED, cla.getCertification());
+    }
+
+    @Test
     void testParseArgumentsFromYaml() throws URISyntaxException {
         String[] args = new String[]{
                 "--config", (new File(getClass().getClassLoader().getResource("test-config.yml").toURI()).getAbsolutePath())
@@ -56,6 +71,7 @@ class CLIApplicationTest {
         assertEquals("exampleB.com",cla.getCertificates().get(2).getHost());
         assertEquals("exampleC.com",cla.getCertificates().get(3).getHost());
         assertEquals("example.com",cla.getCertificates().get(4).getHost());
+        assertEquals(SignatureParameters.CertificationMode.CERTIFIED_NO_CHANGE_PERMITTED, cla.getCertification());
 
     }
 

--- a/src/test/resources/test-config.yml
+++ b/src/test/resources/test-config.yml
@@ -5,6 +5,7 @@ port: 8081 # port where open-pdf-sign is listening
 host: 127.0.0.1 # host address where open-pdf-sign server is listening
 # page: -1 # if not set, no visible signature
 # timestamp: false
+certification: certified-no-change-permitted
 certificates:
   - host: _ # default case
     key: /etc/letsencrypt/live/example.com/key.pem


### PR DESCRIPTION
Fixes #56 #47
Maybe fixes #53

Allow setting the certification level/DocMDP in accordance with [DSS](https://ec.europa.eu/digital-building-blocks/DSS/webapp-demo/doc/dss-documentation.html#CertificationSignatures) and [ISO 32000 12.8.2.2](https://opensource.adobe.com/dc-acrobat-sdk-docs/standards/pdfstandards/pdf/PDF32000_2008.pdf)