### PR TITLE
Extend signature placement support to include right and bottom options

### DIFF
--- a/src/main/java/org/openpdfsign/ImageDimensionCalculator.java
+++ b/src/main/java/org/openpdfsign/ImageDimensionCalculator.java
@@ -1,0 +1,50 @@
+package org.openpdfsign;
+
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+
+import javax.imageio.ImageIO;
+
+public class ImageDimensionCalculator {
+
+    /**
+     * Gets the height of an image given its path and desired width.
+     * 
+     * @param imagePath    The path to the image file.
+     * @param width        The desired width in mm.
+     * @return The calculated height in mm, or -1 if an error occurs.
+     */
+    public static float getImageHeight(String imagePath, float width) {
+        try {
+            // Read the image file
+            BufferedImage image = ImageIO.read(new File(imagePath));
+            
+            // Get original dimensions in pixels
+            int originalWidth = image.getWidth();
+            int originalHeight = image.getHeight();
+
+            // Calculate the aspect ratio
+            float aspectRatio = (float) originalWidth / originalHeight;
+
+            // Calculate the new height maintaining the aspect ratio
+            float height = calculateImageHeight(width, aspectRatio);
+
+            return height;
+        } catch (IOException e) {
+            System.err.println("Error reading the image file. Please ensure the file path is correct.");
+            return 10;
+        }
+    }
+
+    /**
+     * Calculates the height of an image given its width and aspect ratio.
+     * 
+     * @param width        The width of the image in mm.
+     * @param aspectRatio  The aspect ratio of the image (width/height).
+     * @return The calculated height of the image in mm.
+     */
+    private static float calculateImageHeight(float width, float aspectRatio) {
+        return width / aspectRatio;
+    }
+}

--- a/src/main/java/org/openpdfsign/SignatureParameters.java
+++ b/src/main/java/org/openpdfsign/SignatureParameters.java
@@ -1,14 +1,15 @@
 package org.openpdfsign;
 
+import java.util.LinkedList;
+import java.util.List;
+
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.converters.EnumConverter;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import lombok.Getter;
 import lombok.Setter;
-
-import java.util.LinkedList;
-import java.util.List;
 
 @Getter
 @Setter
@@ -27,11 +28,19 @@ public class SignatureParameters {
 
     @Parameter(required = false, names={"--top"}, description = "Y coordinate of the signature block in cm")
     @JsonProperty("top")
-    private float top = 1;
+    private float top = Float.NEGATIVE_INFINITY;
+    
+    @Parameter(required = false, names={"--bottom"}, description = "-Y coordinate of the signature block in cm")
+    @JsonProperty("bottom")
+    private float bottom = Float.NEGATIVE_INFINITY;
 
     @Parameter(required = false, names={"--left"}, description = "X coordinate of the signature block in cm")
     @JsonProperty("left")
-    private float left = 1;
+    private float left = Float.NEGATIVE_INFINITY;
+    
+    @Parameter(required = false, names={"--right"}, description = "-X coordinate of the signature block in cm")
+    @JsonProperty("right")
+    private float right = Float.NEGATIVE_INFINITY;
 
     @Parameter(required = false, names={"--width"}, description = "width of the signature block in cm")
     @JsonProperty("width")

--- a/src/main/java/org/openpdfsign/TableDimensionCalculator.java
+++ b/src/main/java/org/openpdfsign/TableDimensionCalculator.java
@@ -1,0 +1,60 @@
+package org.openpdfsign;
+
+import java.awt.Color;
+
+import org.apache.pdfbox.pdmodel.font.PDType1Font;
+import org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject;
+import org.vandeseer.easytable.settings.HorizontalAlignment;
+import org.vandeseer.easytable.settings.VerticalAlignment;
+import org.vandeseer.easytable.structure.Row;
+import org.vandeseer.easytable.structure.Table;
+import org.vandeseer.easytable.structure.cell.ImageCell;
+import org.vandeseer.easytable.structure.cell.TextCell;
+
+public class TableDimensionCalculator {
+
+    public static float[] calculateTableDimensions(TableSignatureFieldParameters tableParameters, PDImageXObject imageXObject) {
+
+        Table.TableBuilder myTableBuilder = Table.builder();
+
+        final float imageColumnWidth = 75;
+        final float labelColumnWidth = 90;
+        float tableWidth = tableParameters.getWidth();
+        tableWidth = Math.max((imageColumnWidth + labelColumnWidth + 50), tableWidth);
+
+        boolean hasHint = tableParameters.getHint() != null;
+        myTableBuilder
+                .addColumnsOfWidth(imageColumnWidth, labelColumnWidth, (tableWidth - imageColumnWidth - labelColumnWidth))
+                .backgroundColor(Color.WHITE)
+                .borderWidth(0.75f)
+                .padding(5)
+                .fontSize(8)
+                .verticalAlignment(VerticalAlignment.TOP)
+                .addRow(Row.builder()
+                        .add(ImageCell.builder().image(imageXObject).maxHeight(75)
+                                .verticalAlignment(VerticalAlignment.MIDDLE).horizontalAlignment(HorizontalAlignment.CENTER).rowSpan((hasHint ? 3 : 2)).build())
+                        .add(TextCell.builder().text(tableParameters.getLabelSignee()).font(PDType1Font.HELVETICA_BOLD).horizontalAlignment(HorizontalAlignment.RIGHT).build())
+                        .add(TextCell.builder().text(tableParameters.getSignaturString()).build())
+                        .build())
+                .addRow(Row.builder()
+                        .add(TextCell.builder().text(tableParameters.getLabelTimestamp()).font(PDType1Font.HELVETICA_BOLD).horizontalAlignment(HorizontalAlignment.RIGHT).build())
+                        .add(TextCell.builder().text(tableParameters.getSignatureDate()).build())
+                        .build());
+
+        if (hasHint) {
+            myTableBuilder = myTableBuilder.addRow(Row.builder()
+                    .add(TextCell.builder().text(tableParameters.getLabelHint()).font(PDType1Font.HELVETICA_BOLD).horizontalAlignment(HorizontalAlignment.RIGHT).build())
+                    .add(TextCell.builder().text(tableParameters.getHint()).build())
+                    .build());
+        }
+
+        Table myTable = myTableBuilder.build();
+
+        float height = myTable.getHeight();
+        float width = myTable.getWidth();
+
+        return new float[]{height, width};
+
+    }
+
+}


### PR DESCRIPTION
### Description

This pull request extends the functionality of the signature placement feature by adding support for positioning the signature on the **right** and **bottom** sides of the document. Previously, the system supported **left** and **top** placement.

### Changes Made

- Added new options for right and bottom signature placement.
- Refactored existing placement logic to accommodate the new options without affecting existing functionality.

### Why This Change Is Necessary

The addition of right and bottom placement options provides more flexibility in document signing, catering to different layout requirements and user preferences. This enhancement improves the usability and versatility of the signature placement feature.

### Testing

- Verified that the signature can be successfully placed on the right and bottom sides of the document.
- Confirmed that the left and top placement options continue to work as expected.
- Ran unit tests to ensure no regressions were introduced.

### Breaking Changes

None. This change does not introduce any breaking changes and is fully backward-compatible with the existing signature placement functionality.

@cproof Could you please review this pull request when you have a moment? Your feedback would be greatly appreciated.
